### PR TITLE
Add basic Flask web interface for actions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ SQLAlchemy==2.0.41
 psycopg==3.2.9
 mypy==1.17.1
 ruff==0.12.8
+
+Flask==3.0.3

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Action Tracker</title>
+</head>
+<body>
+    <div id="current">
+        <strong>Current Action:</strong> <span id="current-name">None</span><br>
+        <strong>Elapsed:</strong> <span id="elapsed">00:00:00</span>
+    </div>
+
+    <h2>Add Action</h2>
+    <form action="/add_action" method="post">
+        <input name="name" required>
+        <button type="submit">Add</button>
+    </form>
+
+    <h2>Search Actions</h2>
+    <form action="/search" method="get">
+        <input name="q">
+        <button type="submit">Search</button>
+    </form>
+
+    <h2>Switch Action</h2>
+    <form action="/switch" method="post">
+        <input name="action_id" required>
+        <button type="submit">Switch</button>
+    </form>
+
+    <script>
+        function pad(n) { return n.toString().padStart(2, '0'); }
+        let startAt = null;
+        let nameSpan = document.getElementById('current-name');
+        let elapsedSpan = document.getElementById('elapsed');
+
+        async function fetchCurrent() {
+            const res = await fetch('/current_segment');
+            const data = await res.json();
+            if (data && data.start_at) {
+                startAt = new Date(data.start_at);
+                nameSpan.textContent = data.action_name;
+            } else {
+                startAt = null;
+                nameSpan.textContent = 'None';
+                elapsedSpan.textContent = '00:00:00';
+            }
+        }
+
+        function updateElapsed() {
+            if (!startAt) return;
+            const now = new Date();
+            let diff = Math.floor((now - startAt) / 1000);
+            const hrs = Math.floor(diff / 3600);
+            diff %= 3600;
+            const mins = Math.floor(diff / 60);
+            const secs = diff % 60;
+            elapsedSpan.textContent = pad(hrs)+':'+pad(mins)+':'+pad(secs);
+        }
+
+        fetchCurrent();
+        setInterval(updateElapsed, 1000);
+    </script>
+</body>
+</html>

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Search Results</title>
+</head>
+<body>
+    <h2>Search Results for "{{ query }}"</h2>
+    <ul>
+    {% for action in results %}
+        <li>{{ action.id }} - {{ action.name }}</li>
+    {% else %}
+        <li>No matches.</li>
+    {% endfor %}
+    </ul>
+    <a href="/">Back</a>
+</body>
+</html>

--- a/web.py
+++ b/web.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import List
+
+from flask import Flask, jsonify, redirect, render_template, request, url_for
+from sqlalchemy import select
+
+from connection import Session
+from models import Action, ActionSegment
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def index() -> str:
+    return render_template("index.html")
+
+
+@app.route("/current_segment")
+def current_segment() -> str:
+    """Return the currently running segment."""
+    with Session() as session:
+        running = session.scalar(
+            select(ActionSegment).where(ActionSegment.end_at == None)  # noqa: E711
+        )
+        if running is None:
+            return jsonify({"id": None})
+        action = session.scalar(select(Action).where(Action.id == running.action_id))
+        return jsonify(
+            {
+                "id": running.id,
+                "action_id": running.action_id,
+                "action_name": action.name if action else "Unknown",
+                "start_at": running.start_at.isoformat(),
+            }
+        )
+
+
+@app.route("/add_action", methods=["POST"])
+def add_action() -> str:
+    name = request.form.get("name", "").strip()
+    if not name:
+        return "<p>No name provided.</p>"
+    new_action = Action(name=name)
+    with Session() as session:
+        with session.begin():
+            session.add(new_action)
+    return "<p>Action added.</p>"
+
+
+@app.route("/search")
+def search() -> str:
+    query = request.args.get("q", "")
+    with Session() as session:
+        results: List[Action] = session.scalars(
+            select(Action).where(Action.name.like(f"%{query}%"))
+        ).all()
+    return render_template("search_results.html", query=query, results=results)
+
+
+@app.route("/switch", methods=["POST"])
+def switch_action() -> str:
+    action_id = request.form.get("action_id")
+    if not action_id:
+        return redirect(url_for("index"))
+    with Session() as session:
+        with session.begin():
+            running = session.scalar(
+                select(ActionSegment).where(ActionSegment.end_at == None)  # noqa: E711
+            )
+            if running is not None:
+                running.end_at = datetime.now(tz=timezone.utc)
+                session.add(running)
+            new_segment = ActionSegment(
+                action_id=int(action_id), start_at=datetime.now(tz=timezone.utc)
+            )
+            session.add(new_segment)
+    return redirect(url_for("index"))
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- Add a minimal Flask app exposing routes to add actions, search existing actions, view the current running segment, and switch segments
- Build simple vanilla JS front-end that shows a stopwatch for the running segment and provides forms for all actions
- Include search results page and add Flask dependency

## Testing
- `python -m py_compile web.py`


------
https://chatgpt.com/codex/tasks/task_e_68af53662bd0832e87eafd132f153abc